### PR TITLE
Use CMake RESCAN for MKL linking

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -258,12 +258,12 @@ target_link_libraries(faiss_avx2 PRIVATE OpenMP::OpenMP_CXX)
 
 if(MYSCALE_MODE)
   if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
-    target_link_libraries(faiss PRIVATE ${TOOLCHAIN_PATH}/mkl/libmkl_intel_lp64.a)
-    target_link_libraries(faiss PRIVATE ${TOOLCHAIN_PATH}/mkl/libmkl_intel_thread.a)
-    target_link_libraries(faiss PRIVATE ${TOOLCHAIN_PATH}/mkl/libmkl_core.a)
-    target_link_libraries(faiss_avx2 PRIVATE ${TOOLCHAIN_PATH}/mkl/libmkl_intel_lp64.a)
-    target_link_libraries(faiss_avx2 PRIVATE ${TOOLCHAIN_PATH}/mkl/libmkl_intel_thread.a)
-    target_link_libraries(faiss_avx2 PRIVATE ${TOOLCHAIN_PATH}/mkl/libmkl_core.a)
+    target_link_libraries(faiss PRIVATE
+      "$<LINK_GROUP:RESCAN,${TOOLCHAIN_PATH}/mkl/libmkl_intel_lp64.a;${TOOLCHAIN_PATH}/mkl/libmkl_intel_thread.a;${TOOLCHAIN_PATH}/mkl/libmkl_core.a>"
+    )
+    target_link_libraries(faiss_avx2 PRIVATE
+      "$<LINK_GROUP:RESCAN,${TOOLCHAIN_PATH}/mkl/libmkl_intel_lp64.a;${TOOLCHAIN_PATH}/mkl/libmkl_intel_thread.a;${TOOLCHAIN_PATH}/mkl/libmkl_core.a>"
+    )
   elseif (${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64")
     target_link_libraries(faiss PRIVATE ${TOOLCHAIN_PATH}/blas/libblas.a)
     target_link_libraries(faiss_avx2 PRIVATE ${TOOLCHAIN_PATH}/blas/libblas.a)


### PR DESCRIPTION
# What
Resolve static library linking errors on Linux x86-64 builds.

**_Requires CMake 3.24 or higher._**

Without this change I consistently fail to link when following the [build instructions on Ubuntu 20.04 and LLVM 15.0.7](https://github.com/myscale/MyScaleDB/pull/44):

```
stefan@stefan-myscaledb-test2:~/MyScaleDB$ cmake --build build
...
/usr/bin/x86_64-linux-gnu-ld: ../cmake/linux/../../contrib/sysroot/linux-x86_64/mkl/libmkl_core.a(slarft.o): in function `mkl_lapack_slarft':
slarft_gen.f:(.text+0xd61): undefined reference to `mkl_blas_strmm'
/usr/bin/x86_64-linux-gnu-ld: slarft_gen.f:(.text+0x226b): undefined reference to `mkl_blas_strmm'
/usr/bin/x86_64-linux-gnu-ld: ../cmake/linux/../../contrib/sysroot/linux-x86_64/mkl/libmkl_core.a(slarfb.o): in function `mkl_lapack_slarfb':
slarfb_gen.f:(.text+0x20b): undefined reference to `mkl_blas_strmm'
/usr/bin/x86_64-linux-gnu-ld: slarfb_gen.f:(.text+0x344): undefined reference to `mkl_blas_strmm'
/usr/bin/x86_64-linux-gnu-ld: slarfb_gen.f:(.text+0x481): undefined reference to `mkl_blas_strmm'
/usr/bin/x86_64-linux-gnu-ld: ../cmake/linux/../../contrib/sysroot/linux-x86_64/mkl/libmkl_core.a(slarfb.o):slarfb_gen.f:(.text+0x689): more undefined references to `mkl_blas_strmm' follow
/usr/bin/x86_64-linux-gnu-ld: ../cmake/linux/../../contrib/sysroot/linux-x86_64/mkl/libmkl_core.a(slarf.o): in function `mkl_lapack_slarf':
```

... and many other similar symbols.

# How

After snooping around with `nm` on the MKL libraries I noticed all the required symbols are there in the 3 static libs linked, but the linking process is failing because it's not doing multiple passes to resolve the symbols, see this snippet from the build above:

```
: && /usr/bin/clang++-15 --target=x86_64-linux-gnu --sysroot=/home/stefan/MyScaleDB/cmake/linux/../../contrib/sysroot/linux-x86_64/x86_64-linux-gnu/libc --gcc-toolchain=/home/stefan/MyScaleDB/cmake/linux/../../contrib/sysroot/linux-x86_64 -std=c++20
...
 rust/supercrate/libsupercrate.a  contrib/search-index/libmyscale_search_index_static.a  contrib/search-index/contrib/faiss/faiss/libfaiss.a  ../cmake/linux/../../contrib/sysroot/linux-x86_64/mkl/libmkl_intel_lp64.a  ../cmake/linux/../../contrib/sysroot/linux-x86_64/mkl/libmkl_intel_thread.a  ../cmake/linux/../../contrib/sysroot/linux-x86_64/mkl/libmkl_core.a  ../cmake/linux/../../contrib/sysroot/linux-x86_64/lib/x86_64-linux-gnu/libomp.so.5  
...
```
Notice the lack of `-Wl,--start-group` and `-Wl,--end-group`.

It appears the correct way to link static MKL is with multiple passes, see:
* https://github.com/facebookresearch/faiss/issues/96#issuecomment-299108019
* [Intel® oneAPI Math Kernel Library Link Line Advisor](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl-link-line-advisor.html#gs.ge3j5c)

I resolved this problem by using the `RESCAN` [predefined feature introduced in CMake 3.24](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_LINK_GROUP_USING_FEATURE.html#predefined-features):

> Some linkers are single-pass only. For such linkers, circular references between libraries typically result in unresolved symbols. This feature instructs the linker to search the specified static libraries repeatedly until no new undefined references are created.

> Normally, a static library is searched only once in the order that it is specified on the command line. If a symbol in that library is needed to resolve an undefined symbol referred to by an object in a library that appears later on the command line, the linker would not be able to resolve that reference. By grouping the static libraries with the RESCAN feature, they will all be searched repeatedly until all possible references are resolved. This will use linker options like --start-group and --end-group, or on SunOS, -z rescan-start and -z rescan-end.
